### PR TITLE
Fix profile section syntax errors

### DIFF
--- a/src/components/settings/sections/ProfileSection.tsx
+++ b/src/components/settings/sections/ProfileSection.tsx
@@ -261,10 +261,10 @@ export function ProfileSection({
             {type === 'textarea' ? (
               <textarea
                 value={value}
-                onChange={e =>
-                    [fieldKey]: e.target.value,
-                  }) : null)
-                }
+                onChange={e => setLocalEditData(prev => prev ? ({
+                  ...prev,
+                  [fieldKey]: e.target.value,
+                }) : null)}
                 className={`w-full px-3 py-2 bg-white/10 backdrop-blur-sm rounded-lg text-white placeholder-white/50 focus:outline-none focus:ring-2 focus:ring-primary-400 resize-none font-pretendard transition-all ${
                   hasError
                     ? 'ring-2 ring-red-400 bg-red-500/10'
@@ -278,10 +278,10 @@ export function ProfileSection({
               <input
                 type={type}
                 value={value}
-                onChange={e =>
-                    [fieldKey]: e.target.value,
-                  }) : null)
-                }
+                onChange={e => setLocalEditData(prev => prev ? ({
+                  ...prev,
+                  [fieldKey]: e.target.value,
+                }) : null)}
                 className={`w-full px-3 py-2 bg-white/10 backdrop-blur-sm rounded-lg text-white placeholder-white/50 focus:outline-none focus:ring-2 focus:ring-primary-400 font-pretendard transition-all ${
                   hasError
                     ? 'ring-2 ring-red-400 bg-red-500/10'


### PR DESCRIPTION
Fixes syntax errors in `ProfileSection.tsx` by correcting malformed `onChange` handlers and using the correct state setter.

The `onChange` handlers were using incorrect object spread syntax and an undefined `setFormData` function, leading to `Unexpected token` and `Expression expected` errors during build. This PR corrects the syntax to use `setLocalEditData` and proper object spread.

---
<a href="https://cursor.com/background-agent?bcId=bc-f1179640-7a06-4111-aac2-b2a6fe5773d9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f1179640-7a06-4111-aac2-b2a6fe5773d9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

