### PR TITLE
Fix group chat syntax errors

### DIFF
--- a/src/components/family/GroupChat.tsx
+++ b/src/components/family/GroupChat.tsx
@@ -379,10 +379,6 @@ export function GroupChat({
       (!newMessage.trim() && attachments.length === 0) ||
       isSending
     ) {
-      ,
-        attachments: attachments.length,
-        isSending,
-      });
       return;
     }
 
@@ -465,7 +461,8 @@ export function GroupChat({
       setShowEmojiPicker(false);
       inputRef.current?.focus();
     } catch (error) {
-      ?.code,
+      console.error('메시지 전송 오류:', {
+        code: (error as any)?.code,
         message: (error as any)?.message,
         name: (error as any)?.name,
       });


### PR DESCRIPTION
Fix syntax errors in `GroupChat.tsx` by correcting malformed object literals.

---
<a href="https://cursor.com/background-agent?bcId=bc-7d9c9d6e-e803-4ace-9675-7ac88b28b04e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7d9c9d6e-e803-4ace-9675-7ac88b28b04e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

