### PR TITLE
Fix timestamp and svg type errors

### DIFF
--- a/src/components/pages/ProjectDetail.tsx
+++ b/src/components/pages/ProjectDetail.tsx
@@ -15,7 +15,7 @@ interface ProjectData {
   technologies: string[];
   status: string;
   launchDate: string;
-  icon: React.ForwardRefExoticComponent<React.SVGProps<SVGSVGElement> & { size?: number; className?: string }>; // Fixed icon type to match Lucide icons
+  icon: React.ForwardRefExoticComponent<Omit<React.SVGProps<SVGSVGElement>, "ref"> & { size?: number; className?: string }>;
 }
 
 export function ProjectDetail() {

--- a/src/components/points/CompletedTasksList.tsx
+++ b/src/components/points/CompletedTasksList.tsx
@@ -1,4 +1,5 @@
 import { CheckCircle, Clock, RefreshCw, Tag, User } from 'lucide-react';
+import { Timestamp } from 'firebase/firestore';
 import { useCallback, useEffect, useState } from 'react';
 import { useTasks } from '../../hooks/useTasks';
 import { Group } from '../../types/group';

--- a/src/components/points/TaskDetailModal.tsx
+++ b/src/components/points/TaskDetailModal.tsx
@@ -9,6 +9,7 @@ import {
   User,
   X,
 } from 'lucide-react';
+import { Timestamp } from 'firebase/firestore';
 import { Group } from '../../types/group';
 import { Task } from '../../types/task';
 import { toDate } from '../../utils/dateHelpers';


### PR DESCRIPTION
Fixes TypeScript errors related to missing `Timestamp` import and Lucide icon type mismatch.

---
<a href="https://cursor.com/background-agent?bcId=bc-369f4edd-e4ce-4c43-8f3d-2d2b5263f7e7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-369f4edd-e4ce-4c43-8f3d-2d2b5263f7e7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

