### PR TITLE
Run type check and fix syntax error

### DIFF
--- a/src/components/settings/hooks/useSettings.ts
+++ b/src/components/settings/hooks/useSettings.ts
@@ -601,6 +601,7 @@ export function useSettings(): UseSettingsReturn {
       isInitializedRef.current = true;
       loadSettingsInternal();
     }
+  }, [currentUser?.uid, loadSettingsInternal]);
 
   // 1시간마다 자동 동기화 설정
   useEffect(() => {


### PR DESCRIPTION
Fixes a TypeScript error by completing an incomplete `useEffect` hook in `useSettings.ts`.

The `useEffect` hook starting around line 600 was missing its closing `}, [dependencies]);` part, leading to a `TS1005: ')' expected` error at the end of the file. Adding the missing brace and dependency array resolves this syntax issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-e3ddcb05-196d-47b7-bd4f-0121530793a4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e3ddcb05-196d-47b7-bd4f-0121530793a4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

