### PR TITLE
Fix auth context syntax errors

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -138,8 +138,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
                 if (!isSubscribed) return;
 
                 // Initialize FCM for notifications
-                try {
-                }
+                // TODO: Add FCM initialization logic here
 
                 if (!isSubscribed) return;
 
@@ -149,7 +148,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
                   if (isSubscribed) {
                     setUserProfile(profile);
                   }
-                } catch {
+                } catch (error) {
                   if (isSubscribed) {
                     setUserProfile(null);
                   }
@@ -163,18 +162,17 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
                       if (isSubscribed) {
                         setUserProfile(profile);
                       }
-                    },
                     }
                   );
-                } catch {
+                } catch (error) {
                   // Handle error silently
-              }
+                }
             } else {
               setUserProfile(null);
               if (profileUnsubscribe) {
                 try {
                   profileUnsubscribe();
-                } catch {
+                } catch (error) {
                   // Handle error silently
                 }
                 profileUnsubscribe = null;
@@ -186,7 +184,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
             }
           }
         );
-      } catch {
+      } catch (error) {
         if (isSubscribed) {
           setLoading(false);
         }
@@ -201,7 +199,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       if (authUnsubscribe) {
         try {
           authUnsubscribe();
-        } catch {
+        } catch (error) {
           // Handle error silently
         }
       }
@@ -209,7 +207,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       if (profileUnsubscribe) {
         try {
           profileUnsubscribe();
-        } catch {
+        } catch (error) {
           // Handle error silently
         }
       }


### PR DESCRIPTION
Fixes multiple TypeScript syntax errors in `AuthContext.tsx` by correcting `try-catch` block structures and adding missing `error` parameters to `catch` clauses.

---
<a href="https://cursor.com/background-agent?bcId=bc-532046d1-1003-48a7-8d09-2a782e6b0d0a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-532046d1-1003-48a7-8d09-2a782e6b0d0a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

