### PR TITLE
Fix typography and responsive component errors

### DIFF
--- a/src/components/ui/responsive/ResponsiveButton.tsx
+++ b/src/components/ui/responsive/ResponsiveButton.tsx
@@ -7,7 +7,7 @@ import {
 import { cn } from '../../../lib/utils';
 import { ButtonProps } from '../button';
 
-interface ResponsiveButtonProps extends Omit<ButtonProps, 'className'> {
+export interface ResponsiveButtonProps extends Omit<ButtonProps, 'className'> {
   children: React.ReactNode;
   className?: string;
   padding?: 'button' | 'card' | 'container' | 'none';

--- a/src/components/ui/typography.tsx
+++ b/src/components/ui/typography.tsx
@@ -250,21 +250,3 @@ export const Quote = ({
   </Component>
 );
 
-// Export individual components
-export {
-  H1,
-  H2,
-  H3,
-  H4,
-  H5,
-  H6,
-  BodyLarge,
-  Body,
-  BodySmall,
-  Caption,
-  Label,
-  Display,
-  Code,
-  Quote
-};
-


### PR DESCRIPTION
Fixes TypeScript errors by removing duplicate exports in typography and exporting a missing interface.

The `typography.tsx` file had components exported individually and then again in a grouped export block, causing "Cannot redeclare exported variable" errors. The `ResponsiveButtonProps` interface was defined but not exported, leading to "has no exported member" errors when imported elsewhere.

---
<a href="https://cursor.com/background-agent?bcId=bc-0cd6a7db-2ced-4820-8587-d15bda8a7c5c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0cd6a7db-2ced-4820-8587-d15bda8a7c5c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

