### PR TITLE
Fix syntax error in useGroup hook

### DIFF
--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -5,6 +5,9 @@ import { useAuth } from '../hooks/useAuth';
 import { AppState, AppAction, AppNotification, AppContextType } from './AppContextTypes';
 
 
+// Create the context
+const AppContext = createContext<AppContextType | undefined>(undefined);
+
 // Initial State
 const initialState: AppState = {
   currentGroup: null,

--- a/src/hooks/useGroup.ts
+++ b/src/hooks/useGroup.ts
@@ -242,6 +242,9 @@ export function useGroup(options: UseGroupOptions = {}): UseGroupReturn {
 
         return newGroupId;
 
+      } catch (err) {
+        setError('그룹을 생성하는 중 오류가 발생했습니다.');
+        throw err;
       }
     },
     [user]
@@ -259,6 +262,9 @@ export function useGroup(options: UseGroupOptions = {}): UseGroupReturn {
             prev ? ({ ...prev, ...updates } as FamilyGroup) : null
           );
         }
+      } catch (err) {
+        setError('그룹을 업데이트하는 중 오류가 발생했습니다.');
+        throw err;
       }
     },
     [group]
@@ -281,6 +287,9 @@ export function useGroup(options: UseGroupOptions = {}): UseGroupReturn {
           setMembers([]);
           setStats(null);
         }
+      } catch (err) {
+        setError('그룹을 삭제하는 중 오류가 발생했습니다.');
+        throw err;
       }
     },
     [user, group]
@@ -405,6 +414,10 @@ export function useGroup(options: UseGroupOptions = {}): UseGroupReturn {
 
         // Load the newly joined group data
         await loadGroupData(joinedGroupId);
+      } catch (err) {
+        setError('초대 코드로 그룹에 참여하는 중 오류가 발생했습니다.');
+        throw err;
+      }
     },
     [user, loadGroupData]
   );
@@ -456,6 +469,7 @@ export function useUserGroups() {
         setError(null);
         const userGroups = await groupService.getUserGroups(user.uid);
         setGroups(userGroups);
+      } catch (err) {
         setError('사용자 그룹을 불러오는 중 오류가 발생했습니다.');
       } finally {
         setLoading(false);
@@ -473,6 +487,7 @@ export function useUserGroups() {
       setError(null);
       const userGroups = await groupService.getUserGroups(user.uid);
       setGroups(userGroups);
+    } catch (err) {
       setError('사용자 그룹을 다시 불러오는 중 오류가 발생했습니다.');
     } finally {
       setLoading(false);


### PR DESCRIPTION
Fixes build errors by completing try-catch blocks and adding missing context creation.

The build was failing due to incomplete `try-catch` blocks in `useGroup.ts` and a missing `createContext` call for `AppContext` in `AppContext.tsx`. These changes resolve those syntax and initialization issues, allowing the application to build successfully.

---
<a href="https://cursor.com/background-agent?bcId=bc-21c9805a-2149-48a7-bdd7-43372116be78">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-21c9805a-2149-48a7-bdd7-43372116be78">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

