### PR TITLE
Fix unused error variables in hooks

### DIFF
--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -17,7 +17,7 @@ export function useLocalStorage<T>(
     try {
       const item = window.localStorage.getItem(key);
       return item ? deserialize(item) : defaultValue;
-    } catch (_error) {
+    } catch {
       return defaultValue;
     }
   });
@@ -28,7 +28,7 @@ export function useLocalStorage<T>(
         const valueToStore = value instanceof Function ? value(state) : value;
         setState(valueToStore);
         window.localStorage.setItem(key, serialize(valueToStore));
-      } catch (_error) {
+      } catch {
         // Handle error silently
       }
     },
@@ -39,7 +39,7 @@ export function useLocalStorage<T>(
     try {
       window.localStorage.removeItem(key);
       setState(defaultValue);
-    } catch (_error) {
+    } catch {
         // Handle error silently
       }
   }, [key, defaultValue]);
@@ -50,7 +50,7 @@ export function useLocalStorage<T>(
       if (e.key === key && e.newValue !== null) {
         try {
           setState(deserialize(e.newValue));
-        } catch (_error) {
+        } catch {
         // Handle error silently
       }
       }

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -30,7 +30,7 @@ export function useNotifications() {
 
         setNotifications(notificationsData);
         setStats(statsData);
-      } catch (_err) {
+      } catch {
         setError('알림을 불러올 수 없습니다.');
       } finally {
         setLoading(false);
@@ -80,7 +80,7 @@ export function useNotifications() {
             : n
         )
       );
-    } catch (_error) {
+    } catch {
         // Handle error silently
       }
   };
@@ -94,7 +94,7 @@ export function useNotifications() {
       setNotifications(prev =>
         prev.map(n => ({ ...n, status: 'read' as const, readAt: new Date() }))
       );
-    } catch (_error) {
+    } catch {
         // Handle error silently
       }
   };
@@ -104,7 +104,7 @@ export function useNotifications() {
     try {
       await NotificationService.deleteNotification(notificationId);
       setNotifications(prev => prev.filter(n => n.id !== notificationId));
-    } catch (_error) {
+    } catch {
         // Handle error silently
       }
   };

--- a/src/hooks/useOffline.ts
+++ b/src/hooks/useOffline.ts
@@ -58,7 +58,7 @@ export const useOffline = (): UseOfflineReturn => {
       // Re-enable Firestore network
       try {
         await enableNetwork(db);
-        } catch (error) {
+        } catch {
         // Handle error silently
       }
 
@@ -118,7 +118,7 @@ export const useOffline = (): UseOfflineReturn => {
         // Remove successful action from queue
         setPendingActions(prev => prev.filter(a => a.id !== action.id));
         
-        } catch (error) {
+        } catch {
         // Increment retry count
         const updatedAction = { ...action, retry: action.retry + 1 };
         
@@ -176,7 +176,7 @@ export const useOffline = (): UseOfflineReturn => {
     try {
       await disableNetwork(db);
       setIsConnected(false);
-      } catch (error) {
+      } catch {
         // Handle error silently
       }
   }, []);
@@ -185,7 +185,7 @@ export const useOffline = (): UseOfflineReturn => {
     try {
       await enableNetwork(db);
       setIsConnected(true);
-      } catch (error) {
+      } catch {
         // Handle error silently
       }
   }, []);


### PR DESCRIPTION
Remove unused error variables from catch blocks to resolve linting errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-c9241170-9bbd-4ae2-aed3-549d0f533319">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c9241170-9bbd-4ae2-aed3-549d0f533319">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

