### PR TITLE
Fix duplicate task provider export

### DIFF
--- a/src/contexts/TaskContext.tsx
+++ b/src/contexts/TaskContext.tsx
@@ -606,5 +606,3 @@ export function useTask() {
   }
   return context;
 }
-
-export { TaskProvider };


### PR DESCRIPTION
Remove duplicate `export { TaskProvider };` to resolve "Multiple exports with the same name" build error.

---
<a href="https://cursor.com/background-agent?bcId=bc-5fd58969-58a8-481d-bcac-9d5cd065e12b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5fd58969-58a8-481d-bcac-9d5cd065e12b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

