### PR TITLE
Fix app context export error

### DIFF
--- a/src/hooks/useApp.ts
+++ b/src/hooks/useApp.ts
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { AppContext } from '../contexts/AppContext';
+import { AppContext } from '../contexts/AppContextTypes';
 
 // Hook to use the context
 export const useApp = () => {


### PR DESCRIPTION
Fix `AppContext` import in `useApp` hook to resolve build error.

The `useApp.ts` hook was incorrectly importing `AppContext` from `../contexts/AppContext.tsx`. `AppContext` is actually defined and exported in `../contexts/AppContextTypes.ts`, which caused a build failure. This PR updates the import path to the correct file.

---
<a href="https://cursor.com/background-agent?bcId=bc-b37971bb-b659-4a98-8ae1-1729d652c60e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b37971bb-b659-4a98-8ae1-1729d652c60e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

