### PR TITLE
Run test suite and fix errors

### DIFF
--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -16,7 +16,7 @@ export const trackEvent = async (eventName: string, parameters?: Record<string, 
     if (false) {
         // Empty block
       }
-  } catch (error) {
+  } catch {
         // Handle error silently
       }
 };

--- a/src/utils/dateHelpers.ts
+++ b/src/utils/dateHelpers.ts
@@ -37,7 +37,7 @@ export function toDate(
         return new Date();
       }
       return date;
-    } catch (error) {
+    } catch {
       return new Date();
     }
   }
@@ -50,7 +50,7 @@ export function toDate(
         return new Date();
       }
       return date;
-    } catch (error) {
+    } catch {
       return new Date();
     }
   }
@@ -62,7 +62,7 @@ export function toDate(
       return new Date();
     }
     return date;
-  } catch (error) {
+  } catch {
     return new Date();
   }
 }

--- a/src/utils/family.ts
+++ b/src/utils/family.ts
@@ -40,7 +40,7 @@ export const formatRelativeTime = (
       addSuffix,
       locale: ko,
     });
-  } catch (error) {
+  } catch {
     return '날짜 정보 없음';
   }
 };
@@ -62,7 +62,7 @@ export const formatDateTime = (
     }
 
     return format(dateObj, formatString);
-  } catch (error) {
+  } catch {
     return '날짜 정보 없음';
   }
 };
@@ -95,7 +95,7 @@ export const isWithinTimeRange = (
       default:
         return false;
     }
-  } catch (error) {
+  } catch {
     return false;
   }
 };

--- a/src/utils/navigationCallback.ts
+++ b/src/utils/navigationCallback.ts
@@ -7,7 +7,7 @@ export interface NavigationState {
   returnPath?: string;
   returnQuery?: Record<string, string>;
   returnFragment?: string;
-  contextData?: Record<string, any>;
+  contextData?: Record<string, unknown>;
 }
 
 export class NavigationCallback {
@@ -20,7 +20,7 @@ export class NavigationCallback {
     options?: {
       query?: Record<string, string>;
       fragment?: string;
-      contextData?: Record<string, any>;
+      contextData?: Record<string, unknown>;
     }
   ): string {
     const url = new URL(targetPath, window.location.origin);


### PR DESCRIPTION
Resolves linting errors by replacing `any` with `unknown` and removing unused `error` parameters from catch blocks.

---
<a href="https://cursor.com/background-agent?bcId=bc-16fbd220-a332-4372-929c-dd1e051e3942">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-16fbd220-a332-4372-929c-dd1e051e3942">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

