### PR TITLE
Fix unused variables and type errors

### DIFF
--- a/src/utils/navigationCallback.ts
+++ b/src/utils/navigationCallback.ts
@@ -60,7 +60,7 @@ export class NavigationCallback {
     if (returnQuery) {
       try {
         state.returnQuery = JSON.parse(returnQuery);
-      } catch (_error) {
+      } catch {
         // Handle error silently
       }
     }
@@ -76,7 +76,7 @@ export class NavigationCallback {
     if (contextData) {
       try {
         state.contextData = JSON.parse(contextData);
-      } catch (_error) {
+      } catch {
         // Handle error silently
       }
     }
@@ -145,7 +145,7 @@ export class NavigationCallback {
     options?: {
       preserveQuery?: boolean;
       preserveFragment?: boolean;
-      contextData?: Record<string, any>;
+      contextData?: Record<string, unknown>;
     }
   ): string {
     const currentPath = window.location.pathname;

--- a/src/utils/performance.ts
+++ b/src/utils/performance.ts
@@ -30,7 +30,7 @@ export const measurePerformance = async (name: string) => {
       }
       }
     };
-  } catch (_error) {
+  } catch {
     return {
       start: () => {},
       stop: () => {}

--- a/src/utils/pwa.ts
+++ b/src/utils/pwa.ts
@@ -27,7 +27,7 @@ export class PWAManager {
     if ('serviceWorker' in navigator) {
       try {
         await this.registerServiceWorker();
-      } catch (_error) {
+      } catch {
         // Handle error silently
       }
     }
@@ -78,7 +78,7 @@ export class PWAManager {
       });
 
       return registration;
-    } catch (_error) {
+    } catch {
       return null;
     }
   }
@@ -99,7 +99,7 @@ export class PWAManager {
       this.installPrompt = null;
 
       return result.outcome === 'accepted';
-    } catch (_error) {
+    } catch {
       return false;
     }
   }
@@ -133,7 +133,7 @@ export class PWAManager {
           window.location.reload();
         });
       }
-    } catch (_error) {
+    } catch {
         // Handle error silently
       }
   }
@@ -178,7 +178,7 @@ export class PWAManager {
         await Promise.all(
           cacheNames.map(cacheName => caches.delete(cacheName))
         );
-        } catch (_error) {
+        } catch {
         // Handle error silently
       }
     }
@@ -195,7 +195,7 @@ export class PWAManager {
 
     try {
       await this.registration.sync.register(tag);
-      } catch (_error) {
+      } catch {
         // Handle error silently
       }
   }
@@ -248,7 +248,7 @@ export class PWAManager {
     try {
       await navigator.share(data);
       return true;
-    } catch (_error) {
+    } catch (error) {
       if ((error as Error).name !== 'AbortError') {
         }
       return false;


### PR DESCRIPTION
Fixes linting errors by removing unused error variables and specifying `unknown` type instead of `any`.

---
<a href="https://cursor.com/background-agent?bcId=bc-4f9a6e26-c7f3-4752-bfef-1e4cc3aa60e1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4f9a6e26-c7f3-4752-bfef-1e4cc3aa60e1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

