### PR TITLE
Fix unused variable in youtube utils

### DIFF
--- a/src/utils/youtube.ts
+++ b/src/utils/youtube.ts
@@ -42,7 +42,7 @@ export const getYouTubeEmbedUrl = (url: string): string | null => {
     }
     
     return null;
-  } catch (_error) {
+  } catch {
     return null;
   }
 };


### PR DESCRIPTION
Remove unused `_error` parameter from catch block to resolve linting error.

---
<a href="https://cursor.com/background-agent?bcId=bc-8cb473c8-5de9-47e6-9f29-e55d728b5881">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8cb473c8-5de9-47e6-9f29-e55d728b5881">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

