### PR TITLE
Fix unused variables in test suite

### DIFF
--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -92,7 +92,7 @@ export class NotificationService {
           }
 
           return notifications;
-        } catch (_error) {
+        } catch {
           throw new Error(
             '알림 목록을 가져올 수 없습니다. 잠시 후 다시 시도해주세요.'
           );
@@ -136,7 +136,7 @@ export class NotificationService {
         })) as Notification[];
         callback(notifications);
       },
-                  (_error: unknown) => {
+      () => {
         callback([]); // 빈 배열 반환
       }
     );
@@ -156,7 +156,7 @@ export class NotificationService {
         createdAt: Timestamp.now(),
       });
       return docRef.id;
-    } catch (error) {
+    } catch {
       throw new Error('알림을 생성할 수 없습니다.');
     }
   }
@@ -170,7 +170,7 @@ export class NotificationService {
         status: 'read',
         readAt: Timestamp.now(),
       });
-    } catch (error) {
+    } catch {
       throw new Error('알림을 읽음 처리할 수 없습니다.');
     }
   }
@@ -194,7 +194,7 @@ export class NotificationService {
       });
 
       await batch.commit();
-    } catch (error) {
+    } catch {
       throw new Error('알림을 읽음 처리할 수 없습니다.');
     }
   }
@@ -205,7 +205,7 @@ export class NotificationService {
   static async deleteNotification(notificationId: string): Promise<void> {
     try {
       await deleteDoc(doc(db, this.COLLECTION, notificationId));
-    } catch (error) {
+    } catch {
       throw new Error('알림을 삭제할 수 없습니다.');
     }
   }
@@ -234,7 +234,7 @@ export class NotificationService {
       };
 
       return stats;
-    } catch (error) {
+    } catch {
       throw new Error('알림 통계를 가져올 수 없습니다.');
     }
   }
@@ -254,7 +254,7 @@ export class NotificationService {
       }
 
       return null;
-    } catch (error) {
+    } catch {
       throw new Error('알림 설정을 가져올 수 없습니다.');
     }
   }
@@ -270,7 +270,7 @@ export class NotificationService {
         doc(db, this.SETTINGS_COLLECTION, settings.userId),
         settings as Record<string, unknown>
       );
-    } catch (error) {
+    } catch {
       throw new Error('알림 설정을 저장할 수 없습니다.');
     }
   }
@@ -300,7 +300,7 @@ export class NotificationService {
         doc(db, this.SETTINGS_COLLECTION, userId),
         defaultSettings as Record<string, unknown>
       );
-    } catch (error) {
+    } catch {
       throw new Error('기본 알림 설정을 생성할 수 없습니다.');
     }
   }

--- a/src/lib/statisticsAnalyzer.ts
+++ b/src/lib/statisticsAnalyzer.ts
@@ -141,7 +141,7 @@ ${JSON.stringify(timePatterns, null, 2)}
           return Array.isArray(insights) ? 
             insights.map(i => this.validateInsight(i)) : 
             this.getDefaultInsights();
-        } catch (parseError) {
+        } catch {
           return this.getDefaultInsights();
         }
       }


### PR DESCRIPTION
Remove unused error variables from catch blocks to resolve linting errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-3d6894e9-7b24-4664-b2a2-daa25683d3e9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3d6894e9-7b24-4664-b2a2-daa25683d3e9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

