### PR TITLE
Fix unused error variables in statistics analyzer

### DIFF
--- a/src/lib/statisticsAnalyzer.ts
+++ b/src/lib/statisticsAnalyzer.ts
@@ -145,7 +145,7 @@ ${JSON.stringify(timePatterns, null, 2)}
           return this.getDefaultInsights();
         }
       }
-    } catch (error) {
+    } catch (_error) {
       // Handle error silently
     }
 
@@ -214,7 +214,7 @@ ${JSON.stringify(timePatterns, null, 2)}
           return this.getDefaultPrediction(targetPeriod);
         }
       }
-    } catch (error) {
+    } catch (_error) {
       // Handle error silently
     }
 
@@ -303,7 +303,7 @@ ${JSON.stringify(memberPerformance, null, 2)}
           return this.getDefaultTeamAnalysis();
         }
       }
-    } catch (error) {
+    } catch (_error) {
       // Handle error silently
     }
 
@@ -365,7 +365,7 @@ ${JSON.stringify(memberPerformance, null, 2)}
           return this.getDefaultActivityPattern();
         }
       }
-    } catch (error) {
+    } catch (_error) {
       // Handle error silently
     }
 


### PR DESCRIPTION
Fixes linting errors by renaming unused `error` variables to `_error` in `statisticsAnalyzer.ts`.

---
<a href="https://cursor.com/background-agent?bcId=bc-9a629752-b68d-49d3-8145-d4a3c0368d33">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9a629752-b68d-49d3-8145-d4a3c0368d33">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

