### PR TITLE
Remove duplicate DataContext exports

### DIFF
--- a/src/contexts/DataContext.tsx
+++ b/src/contexts/DataContext.tsx
@@ -379,6 +379,3 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
 
   return <DataContext.Provider value={value}>{children}</DataContext.Provider>;
 }
-
-// FIX: Export DataContext for use in utility files
-export { DataContext } from './DataContextTypes';


### PR DESCRIPTION
Remove duplicate export of `DataContext` to resolve build failure due to multiple exports.

---
<a href="https://cursor.com/background-agent?bcId=bc-c277bd21-7530-47ba-bd8e-bb1edff471f9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c277bd21-7530-47ba-bd8e-bb1edff471f9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

