### PR TITLE
Clean up eslint-disable in imageUtils

### DIFF
--- a/src/lib/imageUtils.ts
+++ b/src/lib/imageUtils.ts
@@ -2,11 +2,6 @@
  * 이미지 리사이징 및 압축 유틸리티
  */
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { getDownloadURL, ref, uploadBytes } from 'firebase/storage';
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { storage } from './firebase';
-
 export interface ImageResizeOptions {
   maxWidth: number;
   maxHeight: number;


### PR DESCRIPTION
Remove unused Firebase storage imports and their `eslint-disable` directives from `imageUtils.ts`.

---
<a href="https://cursor.com/background-agent?bcId=bc-23edb195-5eda-480e-a586-809ab65485d6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-23edb195-5eda-480e-a586-809ab65485d6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

