### PR TITLE
Fix duplicate DataContext export

### DIFF
--- a/src/contexts/DataContext.tsx
+++ b/src/contexts/DataContext.tsx
@@ -14,7 +14,11 @@ import {
   GroupMember,
 } from '../types';
 import { useAuth } from '../hooks/useAuth';
-import { DataContextType, DataContext } from './DataContextTypes';
+import { DataContextType } from './DataContextTypes';
+import { createContext } from 'react';
+
+// Create Context locally to avoid multiple exports
+const DataContext = createContext<DataContextType | undefined>(undefined);
 
 export function DataProvider({ children }: { children: React.ReactNode }) {
   const { user, userProfile } = useAuth();
@@ -379,3 +383,7 @@ export function DataProvider({ children }: { children: React.ReactNode }) {
 
   return <DataContext.Provider value={value}>{children}</DataContext.Provider>;
 }
+
+// Export DataContext and DataProvider
+export { DataContext };
+export default DataProvider;


### PR DESCRIPTION
Ensure `DataContext` is exported exactly once to resolve "Multiple exports with the same name" build error.

---
<a href="https://cursor.com/background-agent?bcId=bc-7bd120ce-8d41-41b2-865e-f8364db20a4d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7bd120ce-8d41-41b2-865e-f8364db20a4d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

