### PR TITLE
Update component instrumentation docs to component_v2.0

### DIFF
--- a/docs/컴포넌트_v2.0.md
+++ b/docs/컴포넌트_v2.0.md
@@ -1,0 +1,377 @@
+# Moonwave Plan 컴포넌트_v2.0 사양 및 계측(Instrumentation) 구조
+
+본 문서는 프로젝트 전반에서 컴포넌트 구조와 규약을 v2.0 기준으로 통일하기 위한 표준 사양입니다. 모든 저장소(Repositories)에서 100% 동일하게 복제되어야 하므로, 누락 없이 상세히 기술합니다.
+
+## 0. 적용 범위와 원칙
+
+- **적용 범위**: `src/components`, `src/pages`, `src/layout`, `src/lib`, `src/types`, `src/hooks` 전역에 걸친 UI/도메인 컴포넌트, 페이지 컨테이너, 디자인 시스템, 계측(Instrumentation), 테스트, 접근성 표준.
+- **불변 원칙**:
+  - 모든 컴포넌트는 디자인 토큰과 공통 UI 컴포넌트를 우선 사용한다.
+  - 모든 상호작용 가능한 컴포넌트는 계측 이벤트를 발행한다.
+  - 모든 컴포넌트는 접근성 표준을 준수한다.
+  - PR 전 자동 체크리스트와 테스트를 통과해야 한다.
+
+## 1. 디렉터리 구조(정식)
+
+아래 구조는 모든 저장소에서 동일해야 합니다. 존재하지 않는 폴더는 생성합니다.
+
+```
+src/
+├─ components/
+│  ├─ ui/                    # 기본 UI 컴포넌트 (버튼, 배지, 입력 등)
+│  │  ├─ button.tsx
+│  │  ├─ badge.tsx
+│  │  ├─ input.tsx
+│  │  ├─ textarea.tsx
+│  │  ├─ calendar.tsx
+│  │  ├─ dropdown-menu.tsx
+│  │  ├─ popover.tsx
+│  │  ├─ tabs.tsx
+│  │  ├─ scroll-area.tsx
+│  │  ├─ typography.tsx
+│  │  └─ GlassCard.tsx
+│  ├─ layout/                # 레이아웃/컨테이너 (Header, Footer 등)
+│  ├─ task/                  # 태스크 도메인
+│  │  ├─ TaskCard.tsx
+│  │  ├─ TaskCardEnhanced.tsx
+│  │  └─ TaskDetail.tsx
+│  ├─ family/                # 가족/그룹 도메인
+│  │  ├─ MemberCard.tsx
+│  │  ├─ FamilyActivityWidget.tsx
+│  │  ├─ LeaderBoard.tsx
+│  │  └─ FamilyStats.tsx
+│  ├─ dashboard/             # 대시보드/위젯
+│  │  ├─ ProgressWidget.tsx
+│  │  └─ StatisticsWidget.tsx
+│  ├─ settings/              # 설정/환경
+│  │  ├─ SettingsContainer.tsx
+│  │  ├─ SettingsModal.tsx
+│  │  ├─ SettingsContent.tsx
+│  │  └─ SettingsNavigation.tsx
+│  ├─ charts/                # 차트/시각화
+│  │  ├─ CategoryPieChart.tsx
+│  │  ├─ CompletionChart.tsx
+│  │  ├─ ProgressBar.tsx
+│  │  └─ StreakDisplay.tsx
+│  ├─ ai/                    # AI 컴포넌트
+│  │  ├─ AITaskSuggestions.tsx
+│  │  ├─ ClaudeAssistant.tsx
+│  │  └─ SmartTaskInput.tsx
+│  ├─ common/                # 공통(도메인 비독립적)
+│  └─ instrumentation/       # v2.0 신규: 계측/테레메트리
+│     ├─ events.ts           # 이벤트 이름 상수/팩토리
+│     ├─ schemas.ts          # 이벤트/컨텍스트 타입 정의
+│     ├─ eventBus.ts         # Provider-agnostic 이벤트 버스
+│     ├─ withInstrumentation.tsx # HOC
+│     └─ useTelemetry.ts     # Hook
+├─ pages/                    # 페이지 컨테이너
+├─ layout/                   # 최상위 레이아웃(필요시)
+├─ lib/
+│  ├─ design-tokens.ts      # 디자인 토큰
+│  └─ utils.ts              # 스타일/유틸
+├─ hooks/                    # 비즈/뷰 훅
+└─ types/                    # 전역 타입
+```
+
+## 2. 네이밍/코딩 표준
+
+- 컴포넌트 파일명: `PascalCase.tsx` (예: `TaskCard.tsx`)
+- UI 기본 컴포넌트: `ui/` 하위, 공통 Props 수용
+- 도메인 컴포넌트: `task/`, `family/` 등 도메인 폴더에 배치
+- 내보내기: 각 폴더 `index.ts`에서 명시적 export 권장
+- 타입: 공개 API/Props는 반드시 타입 선언(명시적) 유지
+- 변수/함수명: 축약 금지, 의미 기반 서술적 네이밍
+- 스타일: 디자인 토큰 우선, 임의 하드코딩 금지
+- 접근성: role/aria 속성 및 키보드 내비게이션 필수
+
+## 3. 공통 Props 표준 (모든 컴포넌트)
+
+- `id?: string`
+- `className?: string`
+- `style?: React.CSSProperties`
+- `data-testid?: string` (테스트 고유 식별자)
+- `data-telemetry-id?: string` (계측 고유 식별자)
+- 상호작용 요소는 `aria-label` 또는 표시 텍스트 필수
+
+## 4. 계층 구조 개요
+
+### 4.1 컨테이너 계층
+
+- Layout Container: Header, Footer, ConditionalHeader, WaveBackground
+- Page Container: `src/pages/*`
+- Settings Container: SettingsContainer, SettingsModal, SettingsContent, SettingsNavigation
+- Dashboard Container: ProgressWidget, StatisticsWidget
+
+### 4.2 카드(Card) 계층
+
+- Base: `ui/GlassCard.tsx`
+- Task Cards: TaskCard, TaskCardEnhanced, TaskDetail
+- Family Cards: MemberCard, FamilyActivityWidget, LeaderBoard, FamilyStats
+- Dashboard Cards: ProgressWidget, StatisticsWidget
+
+### 4.3 버튼(Button) 계층
+
+- Base: `ui/button.tsx`
+- WaveButton, FloatingActionButton, QuickAddTask, SettingsToggle 등은 Base 구성/확장
+
+### 4.4 배지(Badge) 계층
+
+- Base: `ui/badge.tsx`
+- 상태/우선순위/카테고리 배지: Base 확장
+
+### 4.5 폼(Form) 계층
+
+- Base: input, textarea, calendar, dropdown-menu, popover, tabs, scroll-area
+- Form Containers: `components/forms/` (확장 포인트)
+
+### 4.6 차트(Chart) 계층
+
+- CategoryPieChart, CompletionChart, ProgressBar, StreakDisplay 등
+
+### 4.7 AI 계층
+
+- AITaskSuggestions, ClaudeAssistant, SmartTaskInput
+
+## 5. 디자인 시스템 적용 순서
+
+1) Design Tokens → 2) UI Components → 3) Specialized Components → 4) Page Styles
+
+## 6. 조합 vs 상속 전략
+
+- 원칙: 조합(Composition) 우선, 필요한 경우 얕은 상속으로 공통 스타일/로직 재사용
+- Base(UI) ↔ Specialized(Domain) 간에는 프리미티브 조합으로 변형도를 확보
+
+## 7. 상태/데이터 처리 표준
+
+- Props 우선(컨트롤드/언컨트롤드 명확화)
+- 비동기: 명시적 로딩/에러/빈 상태 UI
+- 전역 상태 사용 시 의존성 최소화, 주입형 인터페이스 유지
+
+## 8. 계측(Instrumentation) v2.0 표준
+
+v2.0 핵심 추가사항. 모든 저장소에서 동일 구현을 유지합니다.
+
+### 8.1 이벤트 명명 규칙
+
+```
+cmp.<도메인/영역>.<컴포넌트명>.<액션>
+
+예) cmp.ui.button.click, cmp.task.TaskCard.expand, cmp.settings.SettingsToggle.toggle
+```
+
+### 8.2 이벤트 페이로드 스키마
+
+```ts
+// src/components/instrumentation/schemas.ts
+export type TelemetryContext = {
+  userId?: string;
+  sessionId?: string;
+  route?: string;          // 현재 라우트
+  locale?: string;
+  experiment?: string;     // 실험/플래그 키 (선택)
+};
+
+export type TelemetryEvent = {
+  name: string;            // cmp.xxx.yyy
+  component: string;       // 컴포넌트 표시명
+  action: string;          // click|change|mount|visible 등
+  timestamp: number;       // epoch ms
+  traceId?: string;        // 동일 흐름 상관키
+  attributes?: Record<string, unknown>; // 추가 속성
+  context?: TelemetryContext;
+};
+```
+
+### 8.3 이벤트 버스와 Provider-agnostic 전송기
+
+```ts
+// src/components/instrumentation/eventBus.ts
+export interface TelemetrySink {
+  send(event: TelemetryEvent): void | Promise<void>;
+}
+
+export class TelemetryBus {
+  private sinks: TelemetrySink[] = [];
+
+  register(sink: TelemetrySink) {
+    this.sinks.push(sink);
+  }
+
+  async emit(event: TelemetryEvent) {
+    await Promise.all(this.sinks.map((s) => s.send(event)));
+  }
+}
+```
+
+> 구현 메모: Sink는 콘솔, Analytics(SDK), 로그 수집기 등 저장소마다 교체 가능합니다. 이벤트 스키마는 고정해야 합니다.
+
+### 8.4 공통 Hook/HOC
+
+```ts
+// src/components/instrumentation/useTelemetry.ts
+import { useMemo } from 'react';
+
+export function useTelemetry(bus: TelemetryBus, baseContext?: TelemetryContext) {
+  return useMemo(
+    () => ({
+      send: (event: Omit<TelemetryEvent, 'timestamp'>) =>
+        bus.emit({ ...event, timestamp: Date.now(), context: { ...baseContext, ...(event.context || {}) } }),
+    }),
+    [bus, baseContext]
+  );
+}
+
+// src/components/instrumentation/withInstrumentation.tsx
+import React, { useEffect } from 'react';
+
+export function withInstrumentation<P extends { 'data-telemetry-id'?: string }>(
+  Component: React.ComponentType<P>,
+  options: { componentName: string; bus: TelemetryBus }
+) {
+  const { componentName, bus } = options;
+  return function Instrumented(props: P) {
+    useEffect(() => {
+      bus.emit({ name: `cmp.auto.${componentName}.mount`, component: componentName, action: 'mount', timestamp: Date.now() });
+      return () => {
+        bus.emit({ name: `cmp.auto.${componentName}.unmount`, component: componentName, action: 'unmount', timestamp: Date.now() });
+      };
+    }, []);
+    return <Component {...props} />;
+  };
+}
+```
+
+### 8.5 컴포넌트 유형별 필수 이벤트
+
+- 버튼(Button): `click`, `focus`, `disabledClick`
+- 입력(Input/Textarea): `change`, `focus`, `blur`, `validation.error`, `submit`
+- 카드(Card): `mount`, `visibleInViewport`, `expand`, `collapse`, `menu.open`
+- 드롭다운/메뉴: `open`, `close`, `select`
+- 탭/토글: `toggle`, `tab.change`
+- 모달/다이얼로그: `open`, `close`, `confirm`, `cancel`
+- 차트: `render`, `legend.toggle`, `series.hover`
+
+예시(TrackedButton):
+
+```tsx
+// 예시: ui/button.tsx를 감싼 추적 버튼
+type TrackedButtonProps = React.ComponentProps<'button'> & {
+  label?: string;
+  telemetryId?: string;
+  bus: TelemetryBus;
+};
+
+export function TrackedButton({ telemetryId, bus, onClick, label, ...rest }: TrackedButtonProps) {
+  return (
+    <button
+      aria-label={label}
+      data-telemetry-id={telemetryId}
+      onClick={(e) => {
+        bus.emit({
+          name: 'cmp.ui.button.click',
+          component: 'button',
+          action: 'click',
+          timestamp: Date.now(),
+          attributes: { telemetryId },
+        });
+        onClick?.(e);
+      }}
+      {...rest}
+    />
+  );
+}
+```
+
+### 8.6 성능 계측(Perf)
+
+- `web-vitals` 수집: LCP/FID/CLS/INP 등(페이지 레벨)
+- 컴포넌트 마운트/렌더 비용: `performance.now()`로 측정하여 `cmp.perf.<컴포넌트>.render`로 전송
+
+```ts
+export function measureRender(bus: TelemetryBus, component: string, fn: () => void) {
+  const start = performance.now();
+  fn();
+  const end = performance.now();
+  bus.emit({
+    name: `cmp.perf.${component}.render`,
+    component,
+    action: 'render',
+    timestamp: Date.now(),
+    attributes: { ms: end - start },
+  });
+}
+```
+
+## 9. 접근성(A11y) 표준
+
+- 모든 인터랙션 요소에 키보드 탐색 보장(Tab, Enter/Space)
+- `aria-*` 속성, `role` 명확화, 시멘틱 태그 활용
+- 대비/포커스 링, 읽기 순서 보장, Live Region은 필요한 경우만
+
+## 10. 테스트 표준
+
+- 단위 테스트: 이벤트 발생/전파, 상태 변화, 렌더 스냅샷
+- 접근성 테스트: 역할/레이블/탭 순서 검증
+- 시각 회귀(옵션): Storybook/Chromatic 등 도구 사용 가능
+
+## 11. 도입 Step-by-step (—all, —seq, —ultrathink)
+
+1) 폴더 확인: `components/ui`, `components/instrumentation` 유무 확인, 없으면 생성
+2) 디자인 토큰 확인: `lib/design-tokens.ts` 사용 여부 점검
+3) 베이스 UI 사용: 새 컴포넌트는 `ui/*` 조합으로 시작
+4) 공통 Props 적용: `data-testid`, `data-telemetry-id` 수용
+5) 계측 연결: `TelemetryBus` 주입, `useTelemetry` 또는 HOC로 `mount/unmount` 자동 계측 추가
+6) 필수 이벤트 바인딩: 유형별 이벤트(버튼/입력/카드 등) 연결
+7) 접근성 점검: aria/role/키보드 동작 확인
+8) 테스트 추가: 이벤트/접근성/스냅샷
+9) 내보내기: 폴더 `index.ts` 정리 후 페이지 연결
+10) 문서화: 스토리/MDX 또는 README 섹션 갱신
+
+체크리스트(복제용 —all):
+
+- [ ] 폴더 구조 일치
+- [ ] 네이밍/타입 규약 준수
+- [ ] 디자인 토큰만 사용(하드코딩 없음)
+- [ ] 공통 Props 수용
+- [ ] 계측 이벤트 전부 연결(유형별 필수)
+- [ ] 성능 계측 추가(선택적)
+- [ ] 접근성 검증 통과
+- [ ] 테스트 통과
+- [ ] 내보내기/문서 동기화 완료
+
+## 12. v1.0 → v2.0 마이그레이션 가이드
+
+- 기존 컴포넌트에 `data-telemetry-id` 추가
+- 상호작용 핸들러에 이벤트 전송 코드 추가 또는 `withInstrumentation` 적용
+- 페이지 마운트 시 web-vitals 수집 초기화(필요 시)
+- 문서/스토리 업데이트 및 체크리스트 재검토
+
+## 13. 파일 구조 요약(복제용)
+
+```
+src/components/
+├─ ui/
+├─ task/
+├─ family/
+├─ dashboard/
+├─ settings/
+├─ ai/
+├─ charts/
+├─ common/
+└─ instrumentation/
+```
+
+## 14. 부록: 이벤트 이름 예시(권장 세트)
+
+- 버튼: `cmp.ui.button.click`, `cmp.ui.button.focus`, `cmp.ui.button.disabledClick`
+- 입력: `cmp.ui.input.change`, `cmp.ui.input.blur`, `cmp.ui.input.validation.error`, `cmp.ui.form.submit`
+- 카드: `cmp.task.TaskCard.mount`, `cmp.task.TaskCard.visibleInViewport`, `cmp.task.TaskCard.expand`
+- 메뉴: `cmp.ui.dropdown.open`, `cmp.ui.dropdown.select`, `cmp.ui.dropdown.close`
+- 탭/토글: `cmp.ui.tabs.change`, `cmp.ui.toggle.toggle`
+- 모달: `cmp.ui.modal.open`, `cmp.ui.modal.confirm`, `cmp.ui.modal.close`
+- 차트: `cmp.charts.CategoryPieChart.render`, `cmp.charts.ProgressBar.render`
+
+---
+
+본 문서는 `컴포넌트_v2.0` 표준의 단일 출처(Single Source of Truth)입니다. 모든 저장소는 이 사양을 그대로 복제하여 사용해야 하며, 변경 시 버전 넘버를 증가시키고 변경 이력을 별도 문서에 남깁니다.
+


### PR DESCRIPTION
Adds `docs/컴포넌트_v2.0.md` to establish the v2.0 component specification and instrumentation standard for cross-repository consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-ceefbdba-64d0-4da0-a11a-cfe2d71ca9c4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ceefbdba-64d0-4da0-a11a-cfe2d71ca9c4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

